### PR TITLE
Fix: Database connection pool exhaustion causing Slack bot failures

### DIFF
--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -25,8 +25,8 @@ def get_engine():
         if is_production and 'postgresql' in db_url:
             _engine = create_engine(
                 db_url,
-                pool_size=10,  # Reasonable pool size for production
-                max_overflow=20,  # Allow bursts of connections
+                pool_size=2,  # Small pool per worker (4 workers × 2 = 8 base connections)
+                max_overflow=3,  # Allow small bursts (4 workers × 3 = 12 max connections)
                 pool_pre_ping=True,  # Verify connections before using
                 pool_recycle=1800,  # Recycle connections after 30 minutes
                 connect_args={


### PR DESCRIPTION
## Problem
Database connection pool exhaustion preventing Slack bot from initializing in production, causing 503 errors on all Slack commands.

## Root Cause  
- Database allows ~25 connections
- Old config: 4 workers × (pool_size=10 + max_overflow=20) = 120 potential connections
- This exhausts the database connection pool

## Solution
- Reduced pool_size from 10 to 2 per worker
- Reduced max_overflow from 20 to 3 per worker
- New calculation: 4 workers × (2+3) = 20 max connections (within limit)

## Testing
- Verified locally with reduced pool settings
- Will deploy and monitor Slack bot initialization in production